### PR TITLE
feat: 카테고리 리스트 출력 API 구현 및 연동

### DIFF
--- a/src/app/api/task/route.ts
+++ b/src/app/api/task/route.ts
@@ -11,7 +11,7 @@ export async function POST() {
     taskDate: '2023-12-05',
     taskTime: '15:30',
     category: {
-      id: 1,
+      _id: 1,
       name: 'University',
       color: 'bg-red-400',
       icon: '🌈',

--- a/src/app/api/types/category.ts
+++ b/src/app/api/types/category.ts
@@ -1,0 +1,12 @@
+import { CategoryAdd } from '@/types/task/task.type';
+import { ObjectId } from 'mongodb';
+
+export interface ICategoryAdd extends CategoryAdd {
+  email: string;
+  careatedBy: Date;
+}
+export interface ICategory extends CategoryAdd {
+  _id: ObjectId;
+  email: string;
+  careatedBy: Date;
+}

--- a/src/components/organisms/teskDialog/CategoryCreateForm.hook.tsx
+++ b/src/components/organisms/teskDialog/CategoryCreateForm.hook.tsx
@@ -1,10 +1,11 @@
 import { useClientTranslation } from '@/libs/i18n/useClientTranslation';
+import { rqKey } from '@/libs/react-query';
 import { postCategory } from '@/services/category';
 import { CategoryAdd, TASK_FORM_STEP, categoryAddSchema } from '@/types/task/task.type';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { EmojiClickData } from 'emoji-picker-react';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { FieldErrors, useForm } from 'react-hook-form';
 import { toast } from 'react-toastify';
 
@@ -12,7 +13,7 @@ const useCategoryCreateForm = (
   handleSetTaskFormStep: (taskFormStep: TASK_FORM_STEP) => void,
 ) => {
   const { t } = useClientTranslation('taskDialog');
-  const nameInputRef = useRef<HTMLInputElement>(null);
+  const queryClient = useQueryClient();
   const [categoryPreview, setCategoryPreview] = useState<CategoryAdd>({
     color: '',
     icon: '',
@@ -39,10 +40,6 @@ const useCategoryCreateForm = (
     setCategoryPreview((prev) => ({ ...prev, name: watchName }));
   }, [watchName]);
 
-  const handleSaveCategory = () => {
-    handleSetTaskFormStep(TASK_FORM_STEP.CATEGORY);
-  };
-
   const handleSubmitError = (e: FieldErrors<CategoryAdd>) => {
     for (const [key, value] of Object.entries(e)) {
       toast.error(t(value.message!));
@@ -52,7 +49,11 @@ const useCategoryCreateForm = (
 
   const mutation = useMutation({
     mutationFn: postCategory,
-    onSuccess: () => {},
+    onSuccess: () => {
+      toast.success('');
+      handleSetTaskFormStep(TASK_FORM_STEP.CATEGORY);
+      queryClient.invalidateQueries({ queryKey: [rqKey.categories] });
+    },
   });
 
   const handleSubmitSuccess = (newCategory: CategoryAdd) => {
@@ -66,8 +67,6 @@ const useCategoryCreateForm = (
 
   return {
     t,
-    nameInputRef,
-    handleSaveCategory,
     handleClickEmoji,
     categoryPreview,
     handleSetColor,

--- a/src/components/organisms/teskDialog/CategoryCreateForm.tsx
+++ b/src/components/organisms/teskDialog/CategoryCreateForm.tsx
@@ -11,8 +11,6 @@ import Image from 'next/image';
 const CategoryCreateForm = ({ handleSetTaskFormStep }: CategoryCreateFormProps) => {
   const {
     t,
-    nameInputRef,
-    handleSaveCategory,
     handleClickEmoji,
     categoryPreview,
     handleSetColor,

--- a/src/components/organisms/teskDialog/CategorySelectForm.hook.tsx
+++ b/src/components/organisms/teskDialog/CategorySelectForm.hook.tsx
@@ -1,5 +1,8 @@
 import { useClientTranslation } from '@/libs/i18n/useClientTranslation';
+import { rqKey } from '@/libs/react-query';
+import { getCategories } from '@/services/category';
 import { AddTask, Category, TASK_FORM_STEP, Task } from '@/types/task/task.type';
+import { useQuery } from '@tanstack/react-query';
 import React, { useState } from 'react';
 
 export const useCategorySelectForm = (
@@ -9,6 +12,13 @@ export const useCategorySelectForm = (
 ) => {
   const { t } = useClientTranslation('taskDialog');
   const [selectedCategory, setSelectedCategory] = useState<Category>(category);
+
+  const { data } = useQuery({
+    queryFn: getCategories,
+    queryKey: [rqKey.categories],
+  });
+
+  const categories = data?.data;
 
   const handleSelectedCategory = (category: Category) => {
     setSelectedCategory(category);
@@ -25,6 +35,7 @@ export const useCategorySelectForm = (
 
   return {
     t,
+    categories,
     handleSelectedCategory,
     selectedCategory,
     handleSaveCategory,

--- a/src/components/organisms/teskDialog/CategorySelectForm.tsx
+++ b/src/components/organisms/teskDialog/CategorySelectForm.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import { TASK_FORM_STEP } from '@/types/task/task.type';
-import { categories } from './data';
 import Button from '@/components/atoms/button/Button';
 import { useCategorySelectForm } from './CategorySelectForm.hook';
 import { CategorySelectFormProps } from './taskDialog.types';
 import AddIcon from '@/images/icons/add.svg';
+import Link from 'next/link';
+import Image from 'next/image';
 
 const CategorySelectForm = ({
   category,
@@ -13,6 +14,7 @@ const CategorySelectForm = ({
 }: CategorySelectFormProps) => {
   const {
     t,
+    categories,
     handleSelectedCategory,
     selectedCategory,
     handleSaveCategory,
@@ -23,17 +25,19 @@ const CategorySelectForm = ({
     <div className="flex flex-col">
       <div className="my-5 flex-auto">
         <div className="grid grid-cols-4 items-center justify-center gap-y-4 text-center">
-          {categories.map((category) => (
-            <button key={category.id} onClick={() => handleSelectedCategory(category)}>
+          {(categories || []).map((category) => (
+            <button key={category._id} onClick={() => handleSelectedCategory(category)}>
               <div
                 className={`mx-auto h-16 w-16 basis-1/4 rounded-md ${category.color} ${
-                  category.id === selectedCategory?.id
+                  category._id === selectedCategory?._id
                     ? `border-[3px] border-primary`
                     : ''
                 }`}
               >
                 <div className="flex h-full items-center justify-center p-1.5">
-                  <div className="flex-none text-2xl">{category.icon}</div>
+                  <div className="flex-none">
+                    <Image src={category.icon} alt="icon" width={42} height={42} />
+                  </div>
                 </div>
               </div>
               <div className="mt-2 text-sm">{category.name}</div>

--- a/src/components/organisms/teskDialog/data/constants.ts
+++ b/src/components/organisms/teskDialog/data/constants.ts
@@ -7,38 +7,10 @@ export const defaultAddTask: AddTask = {
   taskDate: format(new Date(), 'yyyy-MM-dd'),
   taskTime: '00:00',
   category: {
-    id: 0,
+    _id: 0,
     name: '',
     icon: '',
     color: '',
   },
   priority: 5,
 };
-
-// TODO:TESTCODE
-export const categories: Category[] = [
-  {
-    id: 1,
-    name: 'work',
-    color: 'bg-red-200',
-    icon: '🌈',
-  },
-  {
-    id: 2,
-    name: 'java study',
-    color: 'bg-amber-950',
-    icon: '🔥',
-  },
-  {
-    id: 3,
-    name: 'travel',
-    color: 'bg-yellow-200',
-    icon: '⚡',
-  },
-  {
-    id: 4,
-    name: 'work',
-    color: 'bg-blue-400',
-    icon: '🎶',
-  },
-];

--- a/src/libs/react-query/index.ts
+++ b/src/libs/react-query/index.ts
@@ -1,3 +1,4 @@
 export const rqKey = {
   tasks: 'tasks',
+  categories: 'categories',
 };

--- a/src/libs/redux/slices/taskSlice.ts
+++ b/src/libs/redux/slices/taskSlice.ts
@@ -19,7 +19,7 @@ const initialState: TaskSliceState = {
     taskDate: format(new Date(), 'yyyy-MM-dd'),
     taskTime: '00:00:00',
     category: {
-      id: 0,
+      _id: 0,
       name: '',
       color: '',
       icon: '',

--- a/src/services/category/index.ts
+++ b/src/services/category/index.ts
@@ -1,5 +1,7 @@
 import http from '@/libs/http';
-import { CategoryAdd } from '@/types/task/task.type';
+import { Category, CategoryAdd } from '@/types/task/task.type';
 
 export const postCategory = (newCategory: CategoryAdd) =>
   http.post('/api/category', newCategory);
+
+export const getCategories = () => http.get<Category[]>('/api/category');

--- a/src/types/task/task.type.ts
+++ b/src/types/task/task.type.ts
@@ -1,14 +1,14 @@
 import { InferType, date, number, object, string } from 'yup';
 
 export const categorySchema = object({
-  id: number().required(),
+  _id: number().required(),
   name: string().required(),
   icon: string().required(),
   color: string().required(),
 });
 export type Category = InferType<typeof categorySchema>;
 
-export const categoryAddSchema = categorySchema.omit(['id']);
+export const categoryAddSchema = categorySchema.omit(['_id']);
 export type CategoryAdd = InferType<typeof categoryAddSchema>;
 
 export const taskSchema = object({


### PR DESCRIPTION
- 카테고리 API 구현
- 리스트 출력 구현
- ![image](https://github.com/comeet-lounge-st/todo-fe/assets/92031519/08e856d8-abdb-4f43-936d-375b049c1397)
- 카테고리 타입 `id` -> `_id`로 변경
